### PR TITLE
Transferring identity platform documentation to MSAL.js docs repo

### DIFF
--- a/msal-javascript-conceptual/avoid-page-reloads.md
+++ b/msal-javascript-conceptual/avoid-page-reloads.md
@@ -1,0 +1,147 @@
+---
+title: Avoid page reloads (MSAL.js)
+description: Learn how to avoid page reloads when acquiring and renewing tokens silently using the Microsoft Authentication Library for JavaScript (MSAL.js).
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 05/29/2019
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, devx-track-js
+#Customer intent: As an application developer, I want to learn about avoiding page reloads so I can create more robust applications.
+---
+
+# Avoid page reloads when acquiring and renewing tokens silently using MSAL.js
+
+The Microsoft Authentication Library for JavaScript (MSAL.js) uses hidden `iframe` elements to acquire and renew tokens silently in the background. Microsoft Entra ID returns the token back to the registered `redirect_uri` specified in the token request(by default this is the app's root page). Since the response is a 302, it results in the HTML corresponding to the `redirect_uri` getting loaded in the `iframe`. Usually the app's `redirect_uri` is the root page and this causes it to reload.
+
+In other cases, if navigating to the app's root page requires authentication, it might lead to nested `iframe` elements or `X-Frame-Options: deny` error.
+
+Since MSAL.js cannot dismiss the 302 issued by Microsoft Entra ID and is required to process the returned token, it cannot prevent the `redirect_uri` from getting loaded in the `iframe`.
+
+To avoid the entire app reloading again or other errors caused due to this, please follow these workarounds.
+
+## Specify different HTML for the iframe
+
+Set the `redirect_uri` property on config to a simple page, that does not require authentication. You have to make sure that it matches with the `redirect_uri` registered in Microsoft Entra admin center. This will not affect user's login experience as MSAL saves the start page when user begins the login process and redirects back to the exact location after login is completed.
+
+## Initialization in your main app file
+
+If your app is structured such that there is one central JavaScript file that defines the app's initialization, routing, and other stuff, you can conditionally load your app modules based on whether the app is loading in an `iframe` or not. For example:
+
+In AngularJS: app.js
+
+```javascript
+// Check that the window is an iframe and not popup
+if (window !== window.parent && !window.opener) {
+angular.module('todoApp', ['ui.router', 'MsalAngular'])
+    .config(['$httpProvider', 'msalAuthenticationServiceProvider','$locationProvider', function ($httpProvider, msalProvider,$locationProvider) {
+        msalProvider.init(
+            // msal configuration
+        );
+
+        $locationProvider.html5Mode(false).hashPrefix('');
+    }]);
+}
+else {
+    angular.module('todoApp', ['ui.router', 'MsalAngular'])
+        .config(['$stateProvider', '$httpProvider', 'msalAuthenticationServiceProvider', '$locationProvider', function ($stateProvider, $httpProvider, msalProvider, $locationProvider) {
+            $stateProvider.state("Home", {
+                url: '/Home',
+                controller: "homeCtrl",
+                templateUrl: "/App/Views/Home.html",
+            }).state("TodoList", {
+                url: '/TodoList',
+                controller: "todoListCtrl",
+                templateUrl: "/App/Views/TodoList.html",
+                requireLogin: true
+            })
+
+            $locationProvider.html5Mode(false).hashPrefix('');
+
+            msalProvider.init(
+                // msal configuration
+            );
+        }]);
+}
+```
+
+In Angular: app.module.ts
+
+```javascript
+// Imports...
+@NgModule({
+  declarations: [
+    AppComponent,
+    MsalComponent,
+    MainMenuComponent,
+    AccountMenuComponent,
+    OsNavComponent
+  ],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
+    HttpClientModule,
+    ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production }),
+    MsalModule.forRoot(environment.MsalConfig),
+    SuiModule,
+    PagesModule
+  ],
+  providers: [
+    HttpServiceHelper,
+    {provide: HTTP_INTERCEPTORS, useClass: MsalInterceptor, multi: true},
+    AuthService
+  ],
+  entryComponents: [
+    AppComponent,
+    MsalComponent
+  ]
+})
+export class AppModule {
+  constructor() {
+    console.log('APP Module Constructor!');
+  }
+
+  ngDoBootstrap(ref: ApplicationRef) {
+    if (window !== window.parent && !window.opener)
+    {
+      console.log("Bootstrap: MSAL");
+      ref.bootstrap(MsalComponent);
+    }
+    else
+    {
+    //this.router.resetConfig(RouterModule);
+      console.log("Bootstrap: App");
+      ref.bootstrap(AppComponent);
+    }
+  }
+}
+```
+
+MsalComponent:
+
+```javascript
+import { Component} from '@angular/core';
+import { MsalService } from '@azure/msal-angular';
+
+// This component is used only to avoid Angular reload
+// when doing acquireTokenSilent()
+
+@Component({
+  selector: 'app-root',
+  template: '',
+})
+export class MsalComponent {
+  constructor(private Msal: MsalService) {
+  }
+}
+```
+
+## See also
+
+Learn more about [building a single-page application (SPA)](/azure/active-directory/develop/scenario-spa-overview.md) using MSAL.js.

--- a/msal-javascript-conceptual/b2c-overview.md
+++ b/msal-javascript-conceptual/b2c-overview.md
@@ -1,0 +1,43 @@
+---
+title: Use MSAL.js with Azure AD B2C
+description: The Microsoft Authentication Library for JavaScript (MSAL.js) enables applications to work with Azure AD B2C and acquire tokens to call secured web APIs. These web APIs can be Microsoft Graph, other Microsoft APIs, web APIs from others, or your own web API.
+services: active-directory
+author: henrymbuguakiarie
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 03/07/2023
+ms.author: henrymbugua
+ms.reviewer: nacanuma, negoe
+ms.custom: aaddev devx-track-js
+# Customer intent: As an application developer, I want to learn how MSAL.js can be used with Azure AD B2C for authentication and authorization in my organization's web apps and web APIs that my customers log in to and use.
+---
+
+# Use the Microsoft Authentication Library for JavaScript to work with Azure AD B2C
+
+The [Microsoft Authentication Library for JavaScript (MSAL.js)](https://github.com/AzureAD/microsoft-authentication-library-for-js) enables JavaScript developers to authenticate users with social and local identities using [Azure Active Directory B2C](/azure/active-directory/active-directory-b2c/overview.md) (Azure AD B2C).
+
+By using Azure AD B2C as an identity management service, you can customize and control how your customers sign up, sign in, and manage their profiles when they use your applications.
+
+Azure AD B2C also enables you to brand and customize the UI that your application displays during the authentication process.
+
+## Supported app types and scenarios
+
+MSAL.js enables [single-page applications](../../active-directory-b2c/application-types.md#single-page-applications) to sign-in users with Azure AD B2C using the [authorization code flow with PKCE](/azure/active-directory/active-directory-b2c/authorization-code-flow.md) grant. With MSAL.js and Azure AD B2C:
+
+- Users **can** authenticate with their social and local identities.
+- Users **can** be authorized to access Azure AD B2C protected resources (but not Microsoft Entra protected resources).
+- Users **cannot** obtain tokens for Microsoft APIs (for example, MS Graph API) using [delegated permissions](./permissions-consent-overview.md#permission-types).
+- Users with administrator privileges **can** obtain tokens for Microsoft APIs (for example, MS Graph API) using [delegated permissions](/azure/active-directory/develop/permissions-consent-overview.md#permission-types).
+
+For more information, see: [Working with Azure AD B2C](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/working-with-b2c.md)
+
+## Next steps
+
+Follow the tutorial on how to:
+
+- [Sign in users with Azure AD B2C in a single-page application](/azure/active-directory/active-directory-b2c/configure-authentication-sample-spa-app.md)
+- [Call an Azure AD B2C protected web API](/azure/active-directory/active-directory-b2c/enable-authentication-web-api.md)

--- a/msal-javascript-conceptual/compare-msal-js-and-adal-js.md
+++ b/msal-javascript-conceptual/compare-msal-js-and-adal-js.md
@@ -1,0 +1,553 @@
+---
+title: "Migrate your JavaScript application from ADAL.js to MSAL.js"
+description: How to update your existing JavaScript application to use the Microsoft Authentication Library (MSAL) for authentication and authorization instead of the Active Directory Authentication Library (ADAL).
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 07/06/2021
+ms.author: owenrichards
+ms.custom: has-adal-ref, devx-track-js
+#Customer intent: As an application developer, I want to learn how to change the code in my JavaScript application from using ADAL.js as its authentication library to MSAL.js.
+---
+
+# How to migrate a JavaScript app from ADAL.js to MSAL.js
+
+[Microsoft Authentication Library for JavaScript](https://github.com/AzureAD/microsoft-authentication-library-for-js) (MSAL.js, also known as `msal-browser`) 2.x is the authentication library we recommend using with JavaScript applications on the Microsoft identity platform. This article highlights the changes you need to make to migrate an app that uses the ADAL.js to use MSAL.js 2.x
+
+> [!NOTE]
+> We strongly recommend MSAL.js 2.x over MSAL.js 1.x. The auth code grant flow is more secure and allows single-page applications to maintain a good user experience despite the privacy measures browsers like Safari have implemented to block 3rd party cookies, among other benefits.
+
+## Prerequisites
+
+- You must set the **Platform** / **Reply URL Type** to **Single-page application** on App Registration portal (if you have other platforms added in your app registration, such as **Web**, you need to make sure the redirect URIs don't overlap. See: [Redirect URI restrictions](/azure/active-directory/develop/reply-url.md))
+- You must provide [polyfills](./msal-js-use-ie-browser.md) for ES6 features that MSAL.js relies on (for example, promises) in order to run your apps on **Internet Explorer**
+- Migrate your Microsoft Entra apps to [v2 endpoint](/azure/active-directory/develop/v2-overview.md) if you haven't already
+
+## Install and import MSAL
+
+There are two ways to install the MSAL.js 2.x library:
+
+### Via npm:
+
+```console
+npm install @azure/msal-browser
+```
+
+Then, depending on your module system, import it as shown below:
+
+```javascript
+import * as msal from "@azure/msal-browser"; // ESM
+
+const msal = require('@azure/msal-browser'); // CommonJS
+```
+
+### Via CDN:
+
+Load the script in the header section of your HTML document:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.14.2/js/msal-browser.min.js"></script>
+  </head>
+</html>
+```
+
+For alternative CDN links and best practices when using CDN, see: [CDN Usage](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/cdn-usage.md)
+
+## Initialize MSAL
+
+In ADAL.js, you instantiate the [AuthenticationContext](https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Config-authentication-context#authenticationcontext) class, which then exposes the methods you can use to achieve authentication (`login`, `acquireTokenPopup` etc.). This object serves as the representation of your application's connection to the authorization server or identity provider. When initializing, the only mandatory parameter is the **clientId**:
+
+```javascript
+window.config = {
+  clientId: "YOUR_CLIENT_ID"
+};
+
+var authContext = new AuthenticationContext(config);
+```
+
+In MSAL.js, you instantiate the [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.PublicClientApplication.html) class instead. Like ADAL.js, the constructor expects a [configuration object](#configure-msal) that contains the `clientId` parameter at minimum. See for more: [Initialize MSAL.js](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md)
+
+```javascript
+const msalConfig = {
+  auth: {
+      clientId: 'YOUR_CLIENT_ID'
+  }
+};
+
+const msalInstance = new msal.PublicClientApplication(msalConfig);
+```
+
+In both ADAL.js and MSAL.js, the authority URI defaults to `https://login.microsoftonline.com/common` if you don't specify it.
+
+> [!NOTE]
+> If you use the `https://login.microsoftonline.com/common` authority in v2.0, you will allow users to sign in with any Microsoft Entra organization or a personal Microsoft account (MSA). In MSAL.js, if you want to restrict login to any Microsoft Entra account (same behavior as with ADAL.js), use `https://login.microsoftonline.com/organizations` instead.
+
+## Configure MSAL
+
+Some of the [configuration options in ADAL.js](https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Config-authentication-context) that are used when initializing [AuthenticationContext](https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Config-authentication-context#authenticationcontext) are deprecated in MSAL.js, while some new ones are introduced. See the [full list of available options](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/configuration.md). Importantly, many of these options, except for `clientId`, can be overridden during token acquisition, allowing you to set them on a *per-request* basis. For instance, you can use a different **authority URI** or **redirect URI** than the one you set during initialization when acquiring tokens.
+
+Additionally, you no longer need to specify the login experience (that is, whether using pop-up windows or redirecting the page) via the configuration options. Instead, `MSAL.js` exposes `loginPopup` and `loginRedirect` methods through the `PublicClientApplication` instance.
+
+## Enable logging
+
+In ADAL.js, you configure logging separately at any place in your code:
+
+```javascript
+window.config = {
+  clientId: "YOUR_CLIENT_ID"
+};
+
+var authContext = new AuthenticationContext(config);
+
+var Logging = {
+  level: 3,
+  log: function (message) {
+      console.log(message);
+  },
+  piiLoggingEnabled: false
+};
+
+
+authContext.log(Logging)
+```
+
+In MSAL.js, logging is part of the configuration options and is created during the initialization of `PublicClientApplication`:
+
+```javascript
+const msalConfig = {
+  auth: {
+      // authentication related parameters
+  },
+  cache: {
+      // cache related parameters
+  },
+  system: {
+      loggerOptions: {
+          loggerCallback(loglevel, message, containsPii) {
+              console.log(message);
+          },
+          piiLoggingEnabled: false,
+          logLevel: msal.LogLevel.Verbose,
+      }
+  }
+}
+
+const msalInstance = new msal.PublicClientApplication(msalConfig);
+```
+
+## Switch to MSAL API
+
+Some of the public methods in ADAL.js have equivalents in MSAL.js:
+
+| ADAL                                | MSAL                              | Notes                                        |
+|-------------------------------------|-----------------------------------|----------------------------------------------|
+| `acquireToken`                      | `acquireTokenSilent`              | Renamed and now expects an [account](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#accountinfo) object |
+| `acquireTokenPopup`                 | `acquireTokenPopup`               | Now async and returns a promise              |
+| `acquireTokenRedirect`              | `acquireTokenRedirect`            | Now async and returns a promise              |
+| `handleWindowCallback`              | `handleRedirectPromise`           | Needed if using redirect experience          |
+| `getCachedUser`                     | `getAllAccounts`                  | Renamed and now returns an array of accounts.|
+
+Others were deprecated, while MSAL.js offers new methods:
+
+| ADAL                              | MSAL                            | Notes                                            |
+|-----------------------------------|---------------------------------|--------------------------------------------------|
+| `login`                           | N/A                             | Deprecated. Use `loginPopup` or `loginRedirect`  |
+| `logOut`                          | N/A                             | Deprecated. Use `logoutPopup` or `logoutRedirect`|
+| N/A                               | `loginPopup`                    |                                                  |
+| N/A                               | `loginRedirect`                 |                                                  |
+| N/A                               | `logoutPopup`                   |                                                  |
+| N/A                               | `logoutRedirect`                |                                                  |
+| N/A                               | `getAccountByHomeId`            | Filters accounts by home ID (oid + tenant ID)    |
+| N/A                               | `getAccountLocalId`             | Filters accounts by local ID (useful for ADFS)   |
+| N/A                               | `getAccountUsername`            | Filters accounts by username (if exists)         |
+
+In addition, as MSAL.js is implemented in TypeScript unlike ADAL.js, it exposes various types and interfaces that you can make use of in your projects. See the [MSAL.js API reference](https://azuread.github.io/microsoft-authentication-library-for-js/ref/) for more.
+
+## Use scopes instead of resources
+
+An important difference between the Microsoft Entra ID **v1.0** vs. **v2.0** endpoints is about how the resources are accessed. When using ADAL.js with the **v1.0** endpoint, you would first register a permission on app registration portal, and then request an access token for a resource (such as Microsoft Graph) as shown below:
+
+```javascript
+authContext.acquireTokenRedirect("https://graph.microsoft.com", function (error, token) {
+  // do something with the access token
+});
+```
+
+MSAL.js supports only the **v2.0** endpoint. The **v2.0** endpoint employs a *scope-centric* model to access resources. Thus, when you request an access token for a resource, you also need to specify the scope for that resource:
+
+```javascript
+msalInstance.acquireTokenRedirect({
+  scopes: ["https://graph.microsoft.com/User.Read"]
+});
+```
+
+One advantage of the scope-centric model is the ability to use *dynamic scopes*. When building applications using the v1.0 endpoint, you needed to register the full set of permissions (called *static scopes*) required by the application for the user to consent to at the time of login. In v2.0, you can use the scope parameter to request the permissions at the time you want them (hence, *dynamic scopes*). This allows the user to provide **incremental consent** to scopes. So if at the beginning you just want the user to sign in to your application and you don’t need any kind of access, you can do so. If later you need the ability to read the calendar of the user, you can then request the calendar scope in the acquireToken methods and get the user's consent. See for more: [Resources and scopes](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/resources-and-scopes.md)
+
+## Use promises instead of callbacks
+
+In ADAL.js, callbacks are used for any operation after the authentication succeeds and a response is obtained:
+
+```javascript
+authContext.acquireTokenPopup(resource, extraQueryParameter, claims, function (error, token) {
+  // do something with the access token
+});
+```
+
+In MSAL.js, promises are used instead:
+
+```javascript
+msalInstance.acquireTokenPopup({
+      scopes: ["User.Read"] // shorthand for https://graph.microsoft.com/User.Read
+  }).then((response) => {
+      // do something with the auth response
+  }).catch((error) => {
+      // handle errors
+  });
+```
+
+You can also use the **async/await** syntax that comes with ES8:
+
+```javascript
+const getAccessToken = async() => {
+  try {
+      const authResponse = await msalInstance.acquireTokenPopup({
+          scopes: ["User.Read"]
+      });
+  } catch (error) {
+      // handle errors
+  }
+}
+```
+
+## Cache and retrieve tokens
+
+Like ADAL.js, MSAL.js caches tokens and other authentication artifacts in browser storage, using the [Web Storage API](https://developer.mozilla.org/docs/Web/API/Web_Storage_API). You're recommended to use `sessionStorage` option (see: [configuration](#configure-msal)) because it's more secure in storing tokens that are acquired by your users, but `localStorage` will give you [Single Sign On](/azure/active-directory/develop/msal-js-sso.md) across tabs and user sessions.
+
+Importantly, you aren't supposed to access the cache directly. Instead, you should use an appropriate MSAL.js API for retrieving authentication artifacts like access tokens or user accounts.
+
+## Renew tokens with refresh tokens
+
+ADAL.js uses the [OAuth 2.0 implicit flow](azure/active-directory/develop/v2-oauth2-implicit-grant-flow.md), which doesn't return refresh tokens for security reasons (refresh tokens have longer lifetime than access tokens and are therefore more dangerous in the hands of malicious actors). Hence, ADAL.js performs token renewal using a hidden IFrame so that the user isn't repeatedly prompted to authenticate.
+
+With the auth code flow with PKCE support, apps using MSAL.js 2.x obtain refresh tokens along with ID and access tokens, which can be used to renew them. The usage of refresh tokens is abstracted away, and the developers aren't supposed to build logic around them. Instead, MSAL manages token renewal using refresh tokens by itself. Your previous token cache with ADAL.js won't be transferable to MSAL.js, as the token cache schema has changed and incompatible with the schema used in ADAL.js.
+
+## Handle errors and exceptions
+
+When using MSAL.js, the most common type of error you might face is the `interaction_in_progress` error. This error is thrown when an interactive API (`loginPopup`, `loginRedirect`, `acquireTokenPopup`, `acquireTokenRedirect`) is invoked while another interactive API is still in progress. The `login*` and `acquireToken*` APIs are *async* so you'll need to ensure that the resulting promises have resolved before invoking another one.
+
+Another common error is `interaction_required`. This error is often resolved by initiating an interactive token acquisition prompt. For instance, the web API you're trying to access might have a [Conditional Access](/azure/active-directory/conditional-access/overview.md) policy in place, requiring the user to perform [multifactor authentication](/azure/active-directory/authentication/concept-mfa-howitworks.md) (MFA). In that case, handling `interaction_required` error by triggering `acquireTokenPopup` or `acquireTokenRedirect` will prompt the user for MFA, allowing them to fullfil it.
+
+Yet another common error you might face is `consent_required`, which occurs when permissions required for obtaining an access token for a protected resource aren't consented by the user. As in `interaction_required`, the solution for `consent_required` error is often initiating an interactive token acquisition prompt, using either `acquireTokenPopup` or `acquireTokenRedirect`.
+
+See for more: [Common MSAL.js errors and how to handle them](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/errors.md)
+
+## Use the Events API
+
+MSAL.js (>=v2.4) introduces an events API that you can make use of in your apps. These events are related to the authentication process and what MSAL is doing at any moment, and can be used to update UI, show error messages, check if any interaction is in progress and so on. For instance, below is an event callback that will be called when login process fails for any reason:
+
+```javascript
+const callbackId = msalInstance.addEventCallback((message) => {
+  // Update UI or interact with EventMessage here
+  if (message.eventType === EventType.LOGIN_FAILURE) {
+      if (message.error instanceof AuthError) {
+          // Do something with the error
+      }
+    }
+});
+```
+
+For performance, it's important to unregister event callbacks when they're no longer needed. See for more: [MSAL.js Events API](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/events.md)
+
+## Handle multiple accounts
+
+ADAL.js has the concept of a *user* to represent the currently authenticated entity. MSAL.js replaces *users* with *accounts*, given the fact that a user can have more than one account associated with them. This also means that you now need to control for multiple accounts and choose the appropriate one to work with. The snippet below illustrates this process:
+
+```javascript
+let homeAccountId = null; // Initialize global accountId (can also be localAccountId or username) used for account lookup later, ideally stored in app state
+
+// This callback is passed into `acquireTokenPopup` and `acquireTokenRedirect` to handle the interactive auth response
+function handleResponse(resp) {
+  if (resp !== null) {
+      homeAccountId = resp.account.homeAccountId; // alternatively: resp.account.homeAccountId or resp.account.username
+  } else {
+      const currentAccounts = myMSALObj.getAllAccounts();
+      if (currentAccounts.length < 1) { // No cached accounts
+          return;
+      } else if (currentAccounts.length > 1) { // Multiple account scenario
+          // Add account selection logic here
+      } else if (currentAccounts.length === 1) {
+          homeAccountId = currentAccounts[0].homeAccountId; // Single account scenario
+      }
+  }
+}
+```
+
+For more information, see: [Accounts in MSAL.js](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/accounts.md)
+
+## Use the wrappers libraries
+
+If you're developing for Angular and React frameworks, you can use [MSAL Angular v2](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-angular) and [MSAL React](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-react), respectively. These wrappers expose the same public API as MSAL.js while offering framework-specific methods and components that can streamline the authentication and token acquisition processes.
+
+## Run the app
+
+Once your changes are done, run the app and test your authentication scenario:
+
+```console
+npm start
+```
+
+## Example: Securing a SPA with ADAL.js vs. MSAL.js
+
+The snippets below demonstrates the minimal code required for a single-page application authenticating users with the Microsoft identity platform and getting an access token for Microsoft Graph using first ADAL.js and then MSAL.js:
+
+<table>
+<tr><td> Using ADAL.js </td><td> Using MSAL.js </td></tr>
+<tr>
+<td>
+
+```html
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.0.18/js/adal.min.js"></script>
+</head>
+
+<body>
+    <div>
+        <p id="welcomeMessage" style="visibility: hidden;"></p>
+        <button id="loginButton">Login</button>
+        <button id="logoutButton" style="visibility: hidden;">Logout</button>
+        <button id="tokenButton" style="visibility: hidden;">Get Token</button>
+    </div>
+    <script>
+        // DOM elements to work with
+        var welcomeMessage = document.getElementById("welcomeMessage");
+        var loginButton = document.getElementById("loginButton");
+        var logoutButton = document.getElementById("logoutButton");
+        var tokenButton = document.getElementById("tokenButton");
+
+        // if user is logged in, update the UI
+        function updateUI(user) {
+            if (!user) {
+                return;
+            }
+
+            welcomeMessage.innerHTML = 'Hello ' + user.profile.upn + '!';
+            welcomeMessage.style.visibility = "visible";
+            logoutButton.style.visibility = "visible";
+            tokenButton.style.visibility = "visible";
+            loginButton.style.visibility = "hidden";
+        };
+
+        // attach logger configuration to window
+        window.Logging = {
+            piiLoggingEnabled: false,
+            level: 3,
+            log: function (message) {
+                console.log(message);
+            }
+        };
+
+        // ADAL configuration
+        var adalConfig = {
+            instance: 'https://login.microsoftonline.com/',
+            clientId: "ENTER_CLIENT_ID_HERE",
+            tenant: "ENTER_TENANT_ID_HERE",
+            redirectUri: "ENTER_REDIRECT_URI_HERE",
+            cacheLocation: "sessionStorage",
+            popUp: true,
+            callback: function (errorDesc, token, error, tokenType) {
+                if (error) {
+                    console.log(error, errorDesc);
+                } else {
+                    updateUI(authContext.getCachedUser());
+                }
+            }
+        };
+
+        // instantiate ADAL client object
+        var authContext = new AuthenticationContext(adalConfig);
+
+        // handle redirect response or check for cached user
+        if (authContext.isCallback(window.location.hash)) {
+            authContext.handleWindowCallback();
+        } else {
+            updateUI(authContext.getCachedUser());
+        }
+
+        // attach event handlers to button clicks
+        loginButton.addEventListener('click', function () {
+            authContext.login();
+        });
+
+        logoutButton.addEventListener('click', function () {
+            authContext.logOut();
+        });
+
+        tokenButton.addEventListener('click', () => {
+            authContext.acquireToken(
+                "https://graph.microsoft.com",
+                function (errorDesc, token, error) {
+                    if (error) {
+                        console.log(error, errorDesc);
+
+                        authContext.acquireTokenPopup(
+                            "https://graph.microsoft.com",
+                            null, // extraQueryParameters
+                            null, // claims
+                            function (errorDesc, token, error) {
+                                if (error) {
+                                    console.log(error, errorDesc);
+                                } else {
+                                    console.log(token);
+                                }
+                            }
+                        );
+                    } else {
+                        console.log(token);
+                    }
+                }
+            );
+        });
+    </script>
+</body>
+
+</html>
+
+```
+
+</td>
+<td>
+
+```html
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.34.0/js/msal-browser.min.js"></script>
+</head>
+
+<body>
+    <div>
+        <p id="welcomeMessage" style="visibility: hidden;"></p>
+        <button id="loginButton">Login</button>
+        <button id="logoutButton" style="visibility: hidden;">Logout</button>
+        <button id="tokenButton" style="visibility: hidden;">Get Token</button>
+    </div>
+    <script>
+        // DOM elements to work with
+        const welcomeMessage = document.getElementById("welcomeMessage");
+        const loginButton = document.getElementById("loginButton");
+        const logoutButton = document.getElementById("logoutButton");
+        const tokenButton = document.getElementById("tokenButton");
+
+        // if user is logged in, update the UI
+        const updateUI = (account) => {
+            if (!account) {
+                return;
+            }
+
+            welcomeMessage.innerHTML = `Hello ${account.username}!`;
+            welcomeMessage.style.visibility = "visible";
+            logoutButton.style.visibility = "visible";
+            tokenButton.style.visibility = "visible";
+            loginButton.style.visibility = "hidden";
+        };
+
+        // MSAL configuration
+        const msalConfig = {
+            auth: {
+                clientId: "ENTER_CLIENT_ID_HERE",
+                authority: "https://login.microsoftonline.com/ENTER_TENANT_ID_HERE",
+                redirectUri: "ENTER_REDIRECT_URI_HERE",
+            },
+            cache: {
+                cacheLocation: "sessionStorage"
+            },
+            system: {
+                loggerOptions: {
+                    loggerCallback(loglevel, message, containsPii) {
+                        console.log(message);
+                    },
+                    piiLoggingEnabled: false,
+                    logLevel: msal.LogLevel.Verbose,
+                }
+            }
+        };
+
+        // instantiate MSAL client object
+        const pca = new msal.PublicClientApplication(msalConfig);
+
+        // handle redirect response or check for cached user
+        pca.handleRedirectPromise().then((response) => {
+            if (response) {
+                pca.setActiveAccount(response.account);
+                updateUI(response.account);
+            } else {
+                const account = pca.getAllAccounts()[0];
+                updateUI(account);
+            }
+        }).catch((error) => {
+            console.log(error);
+        });
+
+        // attach event handlers to button clicks
+        loginButton.addEventListener('click', () => {
+            pca.loginPopup().then((response) => {
+                pca.setActiveAccount(response.account);
+                updateUI(response.account);
+            })
+        });
+
+        logoutButton.addEventListener('click', () => {
+            pca.logoutPopup().then((response) => {
+                window.location.reload();
+            });
+        });
+
+        tokenButton.addEventListener('click', () => {
+            const account = pca.getActiveAccount();
+
+            pca.acquireTokenSilent({
+                account: account,
+                scopes: ["User.Read"]
+            }).then((response) => {
+                console.log(response);
+            }).catch((error) => {
+                if (error instanceof msal.InteractionRequiredAuthError) {
+                    pca.acquireTokenPopup({
+                        scopes: ["User.Read"]
+                    }).then((response) => {
+                        console.log(response);
+                    });
+                }
+
+                console.log(error);
+            });
+        });
+    </script>
+</body>
+
+</html>
+
+```
+
+</td>
+</tr>
+</table>
+
+## Next steps
+
+- [MSAL.js API reference](https://azuread.github.io/microsoft-authentication-library-for-js/ref/)
+- [MSAL.js code samples](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples)

--- a/msal-javascript-conceptual/error-handling.md
+++ b/msal-javascript-conceptual/error-handling.md
@@ -1,0 +1,155 @@
+---
+title: Handle errors and exceptions in MSAL.js
+description: Learn how to handle errors and exceptions, Conditional Access claims challenges, and retries in MSAL.js applications.
+services: active-directory
+author: Dickson-Mwendia
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 11/26/2020
+ms.author: dmwendia
+ms.reviewer: saeeda, hahamil
+ms.custom: aaddev, devx-track-js
+---
+# Handle errors and exceptions in MSAL.js
+
+[!INCLUDE [Active directory error handling introduction](./includes/error-handling-and-tips/error-handling-introduction.md)]
+
+## Error handling in MSAL.js
+
+MSAL.js provides error objects that abstract and classify the different types of common errors. It also provides an interface to access specific details of the errors such as error messages to handle them appropriately.
+
+### Error object
+
+```javascript
+export class AuthError extends Error {
+    // This is a short code describing the error
+    errorCode: string;
+    // This is a descriptive string of the error,
+    // and may also contain the mitigation strategy
+    errorMessage: string;
+    // Name of the error class
+    this.name = "AuthError";
+}
+```
+
+By extending the error class, you have access to the following properties:
+- `AuthError.message`:  Same as the `errorMessage`.
+- `AuthError.stack`: Stack trace for thrown errors.
+
+### Error types
+
+The following error types are available:
+
+- `AuthError`: Base error class for the MSAL.js library, also used for unexpected errors.
+
+- `ClientAuthError`: Error class which denotes an issue with Client authentication. Most errors that come from the library are ClientAuthErrors. These errors result from things like calling a login method when login is already in progress, the user cancels the login, and so on.
+
+- `ClientConfigurationError`: Error class, extends `ClientAuthError` thrown before requests are made when the given user config parameters are malformed or missing.
+
+- `ServerError`: Error class, represents the error strings sent by the authentication server. These errors may be invalid request formats or parameters, or any other errors that prevent the server from authenticating or authorizing the user.
+
+- `InteractionRequiredAuthError`: Error class, extends `ServerError` to represent server errors, which require an interactive call. This error is thrown by `acquireTokenSilent` if the user is required to interact with the server to provide credentials or consent for authentication/authorization. Error codes include `"interaction_required"`, `"login_required"`, and `"consent_required"`.
+
+For error handling in authentication flows with redirect methods (`loginRedirect`, `acquireTokenRedirect`), you'll need to handle the redirect promise, which is called with success or failure after the redirect using the `handleRedirectPromise()` method as follows:
+
+```javascript
+const msal = require('@azure/msal-browser');
+const myMSALObj = new msal.PublicClientApplication(msalConfig);
+
+// Register Callbacks for redirect flow
+myMSALObj.handleRedirectPromise()
+    .then(function (response) {
+        //success response
+    })
+    .catch((error) => {
+        console.log(error);
+    })
+myMSALObj.acquireTokenRedirect(request);
+```
+
+The methods for pop-up experience (`loginPopup`, `acquireTokenPopup`) return promises, so you can use the promise pattern (`.then` and `.catch`) to handle them as shown:
+
+```javascript
+myMSALObj.acquireTokenPopup(request).then(
+    function (response) {
+        // success response
+    }).catch(function (error) {
+        console.log(error);
+    });
+```
+
+### Errors that require interaction
+
+An error is returned when you attempt to use a non-interactive method of acquiring a token such as `acquireTokenSilent`, but MSAL couldn't do it silently.
+
+Possible reasons are:
+
+- you need to sign in
+- you need to consent
+- you need to go through a multi-factor authentication experience.
+
+The remediation is to call an interactive method such as `acquireTokenPopup` or `acquireTokenRedirect`:
+
+```javascript
+// Request for Access Token
+myMSALObj.acquireTokenSilent(request).then(function (response) {
+    // call API
+}).catch( function (error) {
+    // call acquireTokenPopup in case of acquireTokenSilent failure
+    // due to interaction required
+    if (error instanceof InteractionRequiredAuthError) {
+        myMSALObj.acquireTokenPopup(request).then(
+            function (response) {
+                // call API
+            }).catch(function (error) {
+                console.log(error);
+            });
+    }
+});
+```
+
+[!INCLUDE [Active directory error handling claims challenges](./includes/error-handling-and-tips/error-handling-claims-challenges.md)]
+
+When getting tokens silently (using `acquireTokenSilent`) using MSAL.js, your application may receive errors when a [Conditional Access claims challenge](v2-conditional-access-dev-guide.md) such as MFA policy is required by an API you're trying to access.
+
+The pattern to handle this error is to make an interactive call to acquire token in MSAL.js such as `acquireTokenPopup` or `acquireTokenRedirect` as in the following example:
+
+```javascript
+myMSALObj.acquireTokenSilent(accessTokenRequest).then(function(accessTokenResponse) {
+    // call API
+}).catch(function(error) {
+    if (error instanceof InteractionRequiredAuthError) {
+    
+        // extract, if exists, claims from the error object
+        if (error.claims) {
+            accessTokenRequest.claims = error.claims,
+        
+        // call acquireTokenPopup in case of InteractionRequiredAuthError failure
+        myMSALObj.acquireTokenPopup(accessTokenRequest).then(function(accessTokenResponse) {
+            // call API
+        }).catch(function(error) {
+            console.log(error);
+        });
+    }
+});
+```
+
+Interactively acquiring the token prompts the user and gives them the opportunity to satisfy the required Conditional Access policy.
+
+When calling an API requiring Conditional Access, you can receive a claims challenge in the error from the API. In this case, you can pass the claims returned in the error to the `claims` parameter in the [access token request object](msal-js-pass-custom-state-authentication-request.md) to satisfy the appropriate policy. 
+
+See [How to use Continuous Access Evaluation enabled APIs in your applications](./app-resilience-continuous-access-evaluation.md) for more detail.
+
+### Using other frameworks
+
+Using toolkits like Tauri for registered single page applications (SPAs) with the identity platform are not recognized for production apps. SPAs only support URLs that start with `https` for production apps and `http://localhost` for local development. Prefixes like `tauri://localhost` cannot be used for browser apps. This format can only be supported for mobile or web apps as they have a confidential component unlike browser apps.
+
+[!INCLUDE [Active directory error handling retries](./includes/error-handling-and-tips/error-handling-retries.md)]
+
+## Next steps
+
+Consider enabling [Logging in MSAL.js](msal-logging-js.md) to help you diagnose and debug issues

--- a/msal-javascript-conceptual/initialize-client-applications.md
+++ b/msal-javascript-conceptual/initialize-client-applications.md
@@ -1,0 +1,162 @@
+---
+title: Initialize MSAL.js client apps
+description: Learn about initializing client applications using the Microsoft Authentication Library for JavaScript (MSAL.js).
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 01/16/2023
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, devx-track-js, engagement-fy23
+# Customer intent: As an application developer, I want to learn about initializing a client application in MSAL.js to enable support for authentication and authorization in a JavaScript single-page application (SPA).
+---
+
+# Initialize client applications using MSAL.js
+
+This article describes initializing the Microsoft Authentication Library for JavaScript (MSAL.js) with an instance of a user-agent application.
+
+The user-agent application is a form of public client application in which the client code is executed in a user-agent such as a web browser. Clients such as these don't store secrets because the browser context is openly accessible.
+
+To learn more about the client application types and application configuration options, see [Public and confidential client apps in MSAL](msal-client-applications.md).
+
+## Prerequisites
+
+Before initializing an application, you first need to [register it in the Microsoft Entra admin center](scenario-spa-app-registration.md), establishing a trust relationship between your application and the Microsoft identity platform.
+
+After registering your app, you'll need some or all of the following values that can be found in the Microsoft Entra admin center.
+
+| Value                   | Required | Description                                                                                                                                                                |
+| :---------------------- | :------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Application (client) ID | Required | A GUID that uniquely identifies your application within the Microsoft identity platform.                                                                                   |
+| Authority               | Optional | The identity provider URL (the _instance_) and the _sign-in audience_ for your application. The instance and sign-in audience, when concatenated, make up the _authority_. |
+| Directory (tenant) ID   | Optional | Specify Directory (tenant) ID if you're building a line-of-business application solely for your organization, often referred to as a _single-tenant application_.          |
+| Redirect URI            | Optional | If you're building a web app, the `redirectUri` specifies where the identity provider (the Microsoft identity platform) should return the security tokens it has issued.   |
+
+## Initialize MSAL.js 2.x apps
+
+Initialize the MSAL.js authentication context by instantiating a [PublicClientApplication][msal-js-publicclientapplication] with a [Configuration][msal-js-configuration] object. The minimum required configuration property is the `clientID` of the application, shown as **Application (client) ID** on the **Overview** page of the app registration in the Microsoft Entra admin center.
+
+Here's an example configuration object and instantiation of a `PublicClientApplication`:
+
+```javascript
+const msalConfig = {
+  auth: {
+    clientId: "Enter_the_Application_Id_Here",
+    authority: "https://login.microsoftonline.com/Enter_the_Tenant_Info_Here",
+    knownAuthorities: [],
+    redirectUri: "https://localhost:{port}/redirect",
+    postLogoutRedirectUri: "https://localhost:{port}/redirect",
+    navigateToLoginRequestUrl: true,
+  },
+  cache: {
+    cacheLocation: "sessionStorage",
+    storeAuthStateInCookie: false,
+  },
+  system: {
+    loggerOptions: {
+      loggerCallback: (
+        level: LogLevel,
+        message: string,
+        containsPii: boolean
+      ): void => {
+        if (containsPii) {
+          return;
+        }
+        switch (level) {
+          case LogLevel.Error:
+            console.error(message);
+            return;
+          case LogLevel.Info:
+            console.info(message);
+            return;
+          case LogLevel.Verbose:
+            console.debug(message);
+            return;
+          case LogLevel.Warning:
+            console.warn(message);
+            return;
+        }
+      },
+      piiLoggingEnabled: false,
+    },
+    windowHashTimeout: 60000,
+    iframeHashTimeout: 6000,
+    loadFrameTimeout: 0,
+  },
+};
+
+// Create an instance of PublicClientApplication
+const msalInstance = new PublicClientApplication(msalConfig);
+
+// Handle the redirect flows
+msalInstance
+  .handleRedirectPromise()
+  .then((tokenResponse) => {
+    // Handle redirect response
+  })
+  .catch((error) => {
+    // Handle redirect error
+  });
+```
+
+### `handleRedirectPromise`
+
+Invoke [handleRedirectPromise][msal-js-handleredirectpromise] when the application uses redirect flows. When using redirect flows, `handleRedirectPromise` should be run on every page load.
+
+Three outcomes are possible from the promise:
+
+- `.then` is invoked and `tokenResponse` is truthy: The application is returning from a redirect operation that was successful.
+- `.then` is invoked and `tokenResponse` is falsy (`null`): The application isn't returning from a redirect operation.
+- `.catch` is invoked: The application is returning from a redirect operation and there was an error.
+
+## Initialize MSAL.js 1.x apps
+
+Initialize the MSAL 1.x authentication context by instantiating a UserAgentApplication with a configuration object. The minimum required configuration property is the `clientID` of your application, shown as **Application (client) ID** on the **Overview** page of the app registration in the Microsoft Entra admin center.
+
+For authentication methods with redirect flows (loginRedirect and acquireTokenRedirect) in MSAL.js 1.2.x or earlier, you must explicitly register a callback for success or error through the `handleRedirectCallback()` method. Explicitly registering the callback is required in MSAL.js 1.2.x and earlier because redirect flows don't return promises like the methods with a pop-up experience do. Registering the callback is _optional_ in MSAL.js version 1.3.x and later.
+
+```javascript
+// Configuration object constructed
+const msalConfig = {
+  auth: {
+    clientId: "Enter_the_Application_Id_Here",
+  },
+};
+
+// Create UserAgentApplication instance
+const msalInstance = new UserAgentApplication(msalConfig);
+
+function authCallback(error, response) {
+  // Handle redirect response
+}
+
+// Register a redirect callback for Success or Error (when using redirect methods)
+// **REQUIRED** in MSAL.js 1.2.x and earlier
+// **OPTIONAL** in MSAL.js 1.3.x and later
+msalInstance.handleRedirectCallback(authCallback);
+```
+
+## Single instance and configuration
+
+Both MSAL.js 1.x and 2.x are designed to have a single instance and configuration of the `UserAgentApplication` or `PublicClientApplication`, respectively, to represent a single authentication context.
+
+Multiple instances of `UserAgentApplication` or `PublicClientApplication` aren't recommended as they can cause conflicting cache entries and behavior in the browser.
+
+## Next steps
+
+The MSAL.js 2.x code sample on GitHub demonstrates instantiation of a [PublicClientApplication][msal-js-publicclientapplication] with a [Configuration][msal-js-configuration] object:
+
+[Azure-Samples/ms-identity-javascript-v2](https://github.com/Azure-Samples/ms-identity-javascript-v2)
+
+<!-- LINKS - External -->
+
+[msal-browser]: https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/
+[msal-core]: https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-core/
+[msal-js-configuration]: https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_browser.PublicClientApplication.html#constructor
+[msal-js-handleredirectpromise]: https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.PublicClientApplication.html#handleredirectpromise 
+[msal-js-publicclientapplication]: https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.PublicClientApplication.html

--- a/msal-javascript-conceptual/known-issues-ie-edge-browsers.md
+++ b/msal-javascript-conceptual/known-issues-ie-edge-browsers.md
@@ -1,0 +1,69 @@
+---
+title: Issues on Internet Explorer & Microsoft Edge (MSAL.js)
+description: Learn about know issues when using the Microsoft Authentication Library for JavaScript (MSAL.js) with Internet Explorer and Microsoft Edge browsers.
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: troubleshooting
+ms.workload: identity
+ms.date: 05/18/2020
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, devx-track-js
+#Customer intent: As an application developer, I want to learn about issues with MSAL.js library so I can decide if this platform meets my application development needs and requirements.
+---
+
+# Known issues on Internet Explorer and Microsoft Edge browsers (MSAL.js)
+
+## Issues due to security zones
+We had multiple reports of issues with authentication in IE and Microsoft Edge (since the update of the *Microsoft Edge browser version to 40.15063.0.0*). We're tracking these and have informed the Microsoft Edge team. While Microsoft Edge works on a resolution, here's a description of the frequently occurring issues and the possible workarounds that can be implemented.
+
+### Cause
+The cause for most of these issues is as follows. The session storage and local storage are partitioned by security zones in the Microsoft Edge browser. In this particular version of Microsoft Edge, when the application is redirected across zones, the session storage and local storage are cleared. Specifically, the session storage is cleared in the regular browser navigation, and both the session and local storage are cleared in the InPrivate mode of the browser. MSAL.js saves certain state in the session storage and relies on checking this state during the authentication flows. When the session storage is cleared, this state is lost and hence results in broken experiences.
+
+### Issues
+
+- **Infinite redirect loops and page reloads during authentication**. When users sign in to the application on Microsoft Edge, they're redirected back from the Microsoft Entra login page and are stuck in an infinite redirect loop resulting in repeated page reloads. This is usually accompanied by an `invalid_state` error in the session storage.
+
+- **Infinite acquire token loops and AADSTS50058 error**. When an application that is run on Microsoft Edge tries to acquire a token for a resource, the application may get stuck in an infinite loop of the acquire token call. The following error is returned from Microsoft Entra ID in your network trace:
+
+    `Error :login_required; Error description:AADSTS50058: A silent sign-in request was sent but no user is signed in. The cookies used to represent the user's session were not sent in the request to Azure AD. This can happen if the user is using Internet Explorer or Edge, and the web app sending the silent sign-in request is in different IE security zone than the Azure AD endpoint (login.microsoftonline.com)`
+
+- **Pop-up window doesn't close or is stuck when using login through pop-up window to authenticate**. When authenticating through a pop-up window in Microsoft Edge or IE (InPrivate), after entering credentials and signing in, if multiple domains across security zones are involved in the navigation, the pop-up window doesn't close because `MSAL.js` loses the handle to the pop-up window.
+
+- **Cannot log in using redirect URL prefixed with tauri**. The only supported schemes for redirect URIs are `https:` for production apps and `http://localhost` for local development. If you attempt to use a different scheme, like `tauri://localhost`, for a mobile or desktop application, the below error message appears. This error arises as a result of how the backend of the SPA is designed.
+
+    `AADSTS90023: Cross-origin token redemption is permitted only for the 'Single-Page Application' client-type or 'Native' client-type with origin registered in AllowedOriginForNativeAppCorsRequestInOAuthToken allow list.`
+
+### Update: Fix available in MSAL.js 0.2.3
+Fixes for the authentication redirect loop issues have been released in [MSAL.js 0.2.3](https://github.com/AzureAD/microsoft-authentication-library-for-js/releases). Enable the flag `storeAuthStateInCookie` in the MSAL.js config to take advantage of this fix. By default this flag is set to false.
+
+When the `storeAuthStateInCookie` flag is enabled, MSAL.js uses the browser cookies to store the request state required for validation of the auth flows.
+
+> [!NOTE]
+> This fix is not yet available for the `msal-angular` and `msal-angularjs` wrappers. This fix doesn't address the issue with pop-up windows.
+
+#### Other workarounds
+Make sure to test that your issue is occurring only on the specific version of Microsoft Edge browser and works on the other browsers before adopting these workarounds.
+1. As a first step to get around these issues, ensure that the application domain and any other sites involved in the redirects of the authentication flow are added as trusted sites in the security settings of the browser. This ensures the redirects belong to the same security zone.
+To do so, follow these steps:
+    - Open **Internet Explorer** and click on the **settings** (gear icon) in the top-right corner
+    - Select **Internet Options**
+    - Select the **Security** tab
+    - Under the **Trusted Sites** option, click on the **sites** button and add the URLs in the dialog box that opens.
+
+4. As mentioned before, since only the session storage is cleared during the regular navigation, you may configure MSAL.js to use the local storage instead. This can be set as the `cacheLocation` config parameter while initializing MSAL.
+
+Note, these workarounds won't solve the issue for InPrivate browsing since both session and local storage are cleared.
+
+## Issues due to popup blockers
+
+There are cases when popups are blocked in IE or Microsoft Edge, for example when a second popup occurs during [multi-factor authentication](../authentication/concept-mfa-howitworks.md). You'll get an alert in the browser to allow for the pop-up window once or always. If you choose to allow, the browser opens the pop-up window automatically and returns a `null` handle for it. As a result, the library doesn't have a handle for the window and there's no way to close the pop-up window. The same issue doesn't happen in Chrome when it prompts you to allow pop-up windows because it doesn't automatically open a pop-up window.
+
+As a **workaround**, developers need to allow popups in IE and Microsoft Edge before they start using their app to avoid this issue.
+
+## Next steps
+Learn more about [Using MSAL.js in Internet Explorer](msal-js-use-ie-browser.md).

--- a/msal-javascript-conceptual/logging.md
+++ b/msal-javascript-conceptual/logging.md
@@ -1,0 +1,80 @@
+---
+title: Logging errors and exceptions in MSAL.js
+description: Learn how to log errors and exceptions in MSAL.js
+services: active-directory
+author: Dickson-Mwendia
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 12/21/2021
+ms.author: dmwendia
+ms.reviewer: saeeda, jmprieur
+ms.custom: aaddev, devx-track-js
+---
+# Logging in MSAL.js
+
+[!INCLUDE [MSAL logging introduction](./includes/error-handling-and-tips/error-logging-introduction.md)]
+
+## Configure logging in MSAL.js
+
+Enable logging in MSAL.js (JavaScript) by passing a loggerOptions object during the configuration for creating a `PublicClientApplication` instance. The only required config parameter is the client ID of the application. Everything else is optional, but may be required depending on your tenant and application model.
+
+The loggerOptions object has the following properties:
+
+- `loggerCallback`: a Callback function that can be provided by the developer to handle the logging of MSAL statements in a custom manner. Implement the `loggerCallback` function depending on how you want to redirect logs. The loggerCallback function has the following format ` (level: LogLevel, message: string, containsPii: boolean): void`
+     - The supported log levels are: `Error`, `Warning`, `Info`, and `Verbose`. The default is `Info`.
+- `piiLoggingEnabled` (optional): if set to true, logs personal and organizational data. By default this is false so that your application doesn't log personal data. Personal data logs are never written to default outputs like Console, Logcat, or NSLog.
+
+```javascript
+import msal from "@azure/msal-browser"
+
+const msalConfig = {
+    auth: {
+        clientId: "enter_client_id_here",
+        authority: "https://login.microsoftonline.com/common",
+        knownAuthorities: [],
+        cloudDiscoveryMetadata: "",
+        redirectUri: "enter_redirect_uri_here",
+        postLogoutRedirectUri: "enter_postlogout_uri_here",
+        navigateToLoginRequestUrl: true,
+        clientCapabilities: ["CP1"]
+    },
+    cache: {
+        cacheLocation: "sessionStorage",
+        storeAuthStateInCookie: false,
+        secureCookies: false
+    },
+    system: {
+        loggerOptions: {
+            logLevel: msal.LogLevel.Verbose,
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {
+                    return;
+                }
+                switch (level) {
+                    case msal.LogLevel.Error:
+                        console.error(message);
+                        return;
+                    case msal.LogLevel.Info:
+                        console.info(message);
+                        return;
+                    case msal.LogLevel.Verbose:
+                        console.debug(message);
+                        return;
+                    case msal.LogLevel.Warning:
+                        console.warn(message);
+                        return;
+                }
+            },
+            piiLoggingEnabled: false
+        },
+    },
+};
+```
+
+## Next steps
+
+For more code samples, refer to [Microsoft identity platform code samples](sample-v2-code.md).

--- a/msal-javascript-conceptual/migrate-spa-implicit-to-auth-code.md
+++ b/msal-javascript-conceptual/migrate-spa-implicit-to-auth-code.md
@@ -1,0 +1,94 @@
+---
+title: Migrate JavaScript single-page app from implicit grant to authorization code flow
+description: How to update a JavaScript SPA using MSAL.js 1.x and the implicit grant flow to MSAL.js 2.x and the authorization code flow with PKCE and CORS support.
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 07/17/2020
+ms.author: owenrichards
+ms.custom: aaddev, devx-track-js
+---
+
+# Migrate a JavaScript single-page app from implicit grant to auth code flow
+
+The Microsoft Authentication Library for JavaScript (MSAL.js) v2.0 brings support for the authorization code flow with PKCE and CORS to single-page applications on the Microsoft identity platform. Follow the steps in the sections below to migrate your MSAL.js 1.x application using the implicit grant to MSAL.js 2.0+ (hereafter *2.x*) and the auth code flow.
+
+MSAL.js 2.x improves on MSAL.js 1.x by supporting the authorization code flow in the browser instead of the implicit grant flow. MSAL.js 2.x does **NOT** support the implicit flow.
+
+## Migration steps
+
+To update your application to MSAL.js 2.x and the auth code flow, there are three primary steps:
+
+1. Switch your [app registration](#switch-redirect-uris-to-spa-platform) redirect URI(s) from **Web** platform to **Single-page application** platform.
+1. Update your [code](#switch-redirect-uris-to-spa-platform) from MSAL.js 1.x to **2.x**.
+1. Disable the [implicit grant](#disable-implicit-grant-settings) in your app registration when all applications sharing the registration have been updated to MSAL.js 2.x and the auth code flow.
+
+The following sections describe each step in additional detail.
+
+## Switch redirect URIs to SPA platform
+
+[!INCLUDE [portal updates](~/articles/active-directory/includes/portal-update.md)]
+
+If you'd like to continue using your existing app registration for your applications, use the Microsoft Entra admin center to update the registration's redirect URIs to the SPA platform. Doing so enables the authorization code flow with PKCE and CORS support for apps that use the registration (you still need to update your application's code to MSAL.js v2.x).
+
+Follow these steps for app registrations that are currently configured with **Web** platform redirect URIs:
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
+1. Browse to **Identity** >  **Applications** > **App registrations**, select your application, and then **Authentication**.
+1. In the **Web** platform tile under **Redirect URIs**, select the warning banner indicating that you should migrate your URIs.
+
+    :::image type="content" source="media/migrate-spa-implicit-to-auth-code/portal-01-implicit-warning-banner.png" alt-text="Implicit flow warning banner on web app tile in Azure portal":::
+1. Select *only* those redirect URIs whose applications will use MSAL.js 2.x, and then select **Configure**.
+
+    :::image type="content" source="media/migrate-spa-implicit-to-auth-code/portal-02-select-redirect-uri.png" alt-text="Select redirect URI pane in SPA pane in Azure portal":::
+
+These redirect URIs should now appear in the **Single-page application** platform tile, showing that CORS support with the authorization code flow and PKCE is enabled for these URIs.
+
+:::image type="content" source="media/migrate-spa-implicit-to-auth-code/portal-03-spa-redirect-uri-tile.png" alt-text="Single-page application tile in app registration in Azure portal":::
+
+You can also [create a new app registration](scenario-spa-app-registration.md) instead of updating the redirect URIs in your existing registration.
+
+## Update your code to MSAL.js 2.x
+
+In MSAL 1.x, you created a application instance by initializing a UserAgentApplication as follows:
+
+```javascript
+// MSAL 1.x
+import * as msal from "msal";
+
+const msalInstance = new msal.UserAgentApplication(config);
+```
+
+In MSAL 2.x, initialize instead a [PublicClientApplication][msal-js-publicclientapplication]:
+
+```javascript
+// MSAL 2.x
+import * as msal from "@azure/msal-browser";
+
+const msalInstance = new msal.PublicClientApplication(config);
+```
+
+For a full walk-through of adding MSAL 2.x to your application, see [Tutorial: Sign in users and call the Microsoft Graph API from a JavaScript single-page app (SPA) using auth code flow](tutorial-v2-javascript-auth-code.md).
+
+For additional changes you might need to make to your code, see the [migration guide](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/v1-migration.md) on GitHub.
+
+## Disable implicit grant settings
+
+Once you've updated all your production applications that use this app registration and its client ID to MSAL 2.x and the authorization code flow, you should uncheck the implicit grant settings under the **Authentication** menu of the app registration.
+
+When you uncheck the implicit grant settings in the app registration, the implicit flow is disabled for all applications using registration and its client ID.
+
+**Do not** disable the implicit grant flow before you've updated all your applications to MSAL.js 2.x and the [PublicClientApplication][msal-js-publicclientapplication].
+
+## Next steps
+
+To learn more about the authorization code flow, including the differences between the implicit and auth code flows, see the [Microsoft identity platform and OAuth 2.0 authorization code flow](v2-oauth2-auth-code-flow.md).
+
+If you'd like to dive deeper into JavaScript single-page application development on the Microsoft identity platform, the multi-part [Scenario: Single-page application](scenario-spa-overview.md) series of articles can help you get started.
+
+<!-- LINKS - external -->
+[msal-js-publicclientapplication]: https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.PublicClientApplication.html

--- a/msal-javascript-conceptual/pass-custom-state-authentication-request.md
+++ b/msal-javascript-conceptual/pass-custom-state-authentication-request.md
@@ -1,0 +1,42 @@
+---
+title: Pass custom state in authentication requests (MSAL.js)
+description: Learn how to pass a custom state parameter value in authentication request using the Microsoft Authentication Library for JavaScript (MSAL.js).
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 01/16/2020
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, devx-track-js
+#Customer intent: As an application developer, I want to learn about passing custom state in authentication requests so I can create more robust applications.
+---
+
+# Pass custom state in authentication requests using MSAL.js
+
+The *state* parameter, as defined by OAuth 2.0, is included in an authentication request and is also returned in the token response to prevent cross-site request forgery attacks. By default, the Microsoft Authentication Library for JavaScript (MSAL.js) passes a randomly generated unique *state* parameter value in the authentication requests.
+
+The state parameter can also be used to encode information of the app's state before redirect. You can pass the user's state in the app, such as the page or view they were on, as input to this parameter. The MSAL.js library allows you to pass your custom state as state parameter in the [Request](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#redirectrequest) object. For example:
+
+```javascript
+import {PublicClientApplication} from "@azure/msal-browser";
+
+const myMsalObj = new PublicClientApplication({
+    clientId: "ENTER_CLIENT_ID_HERE"
+});
+
+let loginRequest = {
+    scopes: ["user.read"],
+    state: "page_url"
+}
+
+myMSALObj.loginRedirect(loginRequest);
+```
+
+The passed in state is appended to the unique GUID set by MSAL.js when sending the request. When the response is returned, MSAL.js checks for a state match and then returns the custom passed in state in the [Response](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#authenticationresult) object as `state`.
+
+To learn more, read about [building a single-page application (SPA)](scenario-spa-overview.md) using MSAL.js.

--- a/msal-javascript-conceptual/prompt-behavior.md
+++ b/msal-javascript-conceptual/prompt-behavior.md
@@ -1,0 +1,92 @@
+---
+title: Prompt behavior with MSAL.js
+description: Learn to customize prompt behavior using the Microsoft Authentication Library for JavaScript (MSAL.js).
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: how-to
+ms.workload: identity
+ms.date: 04/24/2019
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, devx-track-js
+#Customer intent: As an application developer, I want to learn about customizing the UI prompt behaviors in MSAL.js library so I can decide if this platform meets my application development needs and requirements.
+---
+
+# Prompt behavior with MSAL.js
+
+MSAL.js allows passing a prompt value as part of its login or token request methods. Based on your application scenario, you can customize the Microsoft Entra prompt behavior for a request by setting the **prompt** parameter in the [request object](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#commonauthorizationurlrequest): 
+
+```javascript
+import { PublicClientApplication } from "@azure/msal-browser";
+
+const pca = new PublicClientApplication({
+    auth: {
+        clientId: "YOUR_CLIENT_ID"
+    }
+});
+
+const loginRequest = {
+    scopes: ["user.read"],
+    prompt: 'select_account',
+}
+
+pca.loginPopup(loginRequest)
+    .then(response => {
+        // do something with the response
+    })
+    .catch(error => {
+        // handle errors
+    });
+```
+
+## Supported prompt values
+
+The following prompt values can be used when authenticating with the Microsoft identity platform:
+
+| Parameter  | Behavior                                                                         |
+|------------|----------------------------------------------------------------------------------|
+| `login`  | Forces the user to enter their credentials on that request, negating single-sign on. |
+| `none`  | Ensures that the user isn't presented with any interactive prompt. If the request can't be completed silently by using single-sign on, the Microsoft identity platform returns a *login_required* or *interaction_required* error. |
+| `consent`  | Triggers the OAuth consent dialog after the user signs in, asking the user to grant permissions to the app. |
+| `select_account` | Interrupts single sign-on by providing an account selection experience listing all the accounts in session or an option to choose a different account altogether. |
+| `create` | Triggers a sign-up dialog allowing external users to create an account. For more information, see: [Self-service sign-up](../external-identities/self-service-sign-up-overview.md) |
+
+MSAL.js will throw an `invalid_prompt` error for any unsupported prompt values:
+
+```console
+invalid_prompt_value: Supported prompt values are 'login', 'select_account', 'consent', 'create' and 'none'. Please see here for valid configuration options: https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#commonauthorizationurlrequest Given value: my_custom_prompt
+```
+
+## Default prompt values
+
+The following shows default prompt values that MSAL.js uses:
+
+| MSAL.js method         | Default prompt | Allowed prompts |
+|------------------------|----------------|-----------------|
+| `loginPopup`           | N/A            | Any             |
+| `loginRedirect`        | N/A            | Any             |
+| `ssoSilent`            | `none`         | N/A (ignored)   |
+| `acquireTokenPopup`    | N/A            | Any             |
+| `acquireTokenRedirect` | N/A            | Any             |
+| `acquireTokenSilent`   | `none`         | N/A (ignored)   |
+
+> [!NOTE]
+> Note that **prompt** is a protocol-level parameter and signals the desired authentication behavior to the identity provider. It does not affect MSAL.js behavior and MSAL.js does not have control over how the service will ultimately handle the request. In most circumstances, Microsoft Entra ID will try to honor the request. If this is not possible, it may return an error response, or completely ignore the given prompt value.
+
+## Interactive requests with prompt=none
+
+Generally, when you need to make a silent request, use a silent MSAL.js method (`ssoSilent`, `acquireTokenSilent`), and handle any *login_required* or *interaction_required* errors with an interactive method (`loginPopup`, `loginRedirect`, `acquireTokenPopup`, `acquireTokenRedirect`). 
+
+In some cases however, the prompt value `none` can be used together with an interactive MSAL.js method to achieve silent authentication. For instance, due to the third-party cookie restrictions in some browsers, `ssoSilent` requests will fail despite an active user session with Microsoft Entra ID. As a remedy, you can pass the prompt value `none` to an interactive request such as `loginPopup`. MSAL.js will then open a popup window to Microsoft Entra ID and Microsoft Entra ID will honor the prompt value by utilizing the existing session cookie. In this case, the user will see a brief popup window but will not be prompted for a credential entry.
+
+## Next steps
+
+- [Single sign-on with MSAL.js](msal-js-sso.md)
+- [Handle errors and exceptions in MSAL.js](msal-error-handling-js.md)
+- [Handle ITP in Safari and other browsers where third-party cookies are blocked](reference-third-party-cookies-spas.md)
+- [OAuth 2.0 authorization code flow on the Microsoft identity platform](v2-oauth2-auth-code-flow.md)
+- [OpenID Connect on the Microsoft identity platform](v2-protocols-oidc.md)

--- a/msal-javascript-conceptual/single-sign-on.md
+++ b/msal-javascript-conceptual/single-sign-on.md
@@ -1,0 +1,222 @@
+---
+title: Single sign-on (MSAL.js)
+description: Learn about building single sign-on experiences using the Microsoft Authentication Library for JavaScript (MSAL.js).
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 01/16/2023
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, has-adal-ref, engagement-fy23, devx-track-js
+#Customer intent: As an application developer, I want to learn about enabling single sign on experiences with MSAL.js library so I can decide if this platform meets my application development needs and requirements.
+---
+
+# Single sign-on with MSAL.js
+
+Single sign-on (SSO) provides a more seamless experience by reducing the number of times a user is asked for credentials. Users enter their credentials once, and the established session can be reused by other applications on the same device without further prompting.
+
+Microsoft Entra ID enables SSO by setting a session cookie when a user authenticates for the first time. MSAL.js also caches the ID tokens and access tokens of the user in the browser storage per application domain. The two mechanisms, Microsoft Entra session cookie and Microsoft Authentication Library (MSAL) cache, are independent of each other but work together to provide SSO behavior.
+
+## SSO between browser tabs for the same app
+
+When a user has an application open in several tabs and signs in on one of them, they can be signed into the same app open on other tabs without being prompted. To do so, you need to set the *cacheLocation* in MSAL.js configuration object to `localStorage` as shown in the following example:
+
+```javascript
+const config = {
+  auth: {
+    clientId: "1111-2222-3333-4444-55555555",
+  },
+  cache: {
+    cacheLocation: "localStorage",
+  },
+};
+
+const msalInstance = new msal.PublicClientApplication(config);
+```
+
+In this case, application instances in different browser tabs make use of the same MSAL cache, thus sharing the authentication state between them. You can also use MSAL events for updating application instances when a user logs in from another browser tab or window. For more information, see: [Syncing logged in state across tabs and windows](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/events.md#syncing-logged-in-state-across-tabs-and-windows)
+
+## SSO between different apps
+
+When a user authenticates, a session cookie is set on the Microsoft Entra domain in the browser. MSAL.js relies on this session cookie to provide SSO for the user between different applications. In particular, MSAL.js offers the `ssoSilent` method to sign-in the user and obtain tokens without an interaction. However, if the user has multiple user accounts in a session with Microsoft Entra ID, they're then prompted to pick an account to sign in with. As such, there are two ways to achieve SSO using `ssoSilent` method.
+
+### With user hint
+
+To improve performance and ensure that the authorization server will look for the correct account session, you can pass one of the following options in the request object of the `ssoSilent` method to obtain the token silently.
+
+- `login_hint`, which can be retrieved from the `account` object username property or the `upn` claim in the ID token. If your app is authenticating users with B2C, see: [Configure B2C user-flows to emit username in ID tokens](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/FAQ.md#why-is-getaccountbyusername-returning-null-even-though-im-signed-in)
+- Session ID, `sid`, which can be retrieved from `idTokenClaims` of an `account` object. 
+- `account`, which can be retrieved from using one the [account methods](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#account-apis)
+
+
+ We recommended to using the `login_hint` [optional ID token claim](optional-claims-reference.md#v10-and-v20-optional-claims-set) provided to `ssoSilent` as `loginHint` as it is the most reliable account hint of silent and interactive requests.
+
+
+#### Using a login hint
+
+The `login_hint` optional claim provides a hint to Microsoft Entra ID about the user account attempting to sign in. To bypass the account selection prompt typically shown during interactive authentication requests, provide the `loginHint` as shown:
+
+```javascript
+const silentRequest = {
+    scopes: ["User.Read", "Mail.Read"],
+    loginHint: "user@contoso.com"
+};
+
+try {
+    const loginResponse = await msalInstance.ssoSilent(silentRequest);
+} catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+        const loginResponse = await msalInstance.loginPopup(silentRequest).catch(error => {
+            // handle error
+        });
+    } else {
+        // handle error
+    }
+}
+```
+
+In this example, `loginHint` contains the user's email or UPN, which is used as a hint during interactive token requests. The hint can be passed between applications to facilitate silent SSO, where application A can sign in a user, read the `loginHint`, and then send the claim and the current tenant context to application B. Microsoft Entra ID will attempt to pre-fill the sign-in form or bypass the account selection prompt and directly proceed with the authentication process for the specified user.
+
+If the information in the `login_hint` claim doesn't match any existing user, they're redirected to go through the standard sign-in experience, including account selection.  
+
+#### Using a session ID
+
+To use a session ID, add `sid` as an [optional claim](./optional-claims.md) to your app's ID tokens. The `sid` claim allows an application to identify a user's Microsoft Entra session independent of their account name or username. To learn how to add optional claims like `sid`, see [Provide optional claims to your app](./optional-claims.md). Use the session ID (SID) in silent authentication requests you make with `ssoSilent` in MSAL.js.
+
+```javascript
+const request = {
+  scopes: ["user.read"],
+  sid: sid,
+};
+
+ try {
+    const loginResponse = await msalInstance.ssoSilent(request);
+} catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+        const loginResponse = await msalInstance.loginPopup(request).catch(error => {
+            // handle error
+        });
+    } else {
+        // handle error
+    }
+}
+```
+
+#### Using an account object
+
+If you know the user account information, you can also retrieve the user account by using the `getAccountByUsername()` or `getAccountByHomeId()` methods:
+
+```javascript
+const username = "test@contoso.com";
+const myAccount  = msalInstance.getAccountByUsername(username);
+
+const request = {
+    scopes: ["User.Read"],
+    account: myAccount
+};
+
+try {
+    const loginResponse = await msalInstance.ssoSilent(request);
+} catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+        const loginResponse = await msalInstance.loginPopup(request).catch(error => {
+            // handle error
+        });
+    } else {
+        // handle error
+    }
+}
+```
+
+### Without user hint
+
+You can attempt to use the `ssoSilent` method without passing any `account`, `sid` or `login_hint` as shown in the following code:
+
+```javascript
+const request = {
+    scopes: ["User.Read"]
+};
+
+try {
+    const loginResponse = await msalInstance.ssoSilent(request);
+} catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+        const loginResponse = await msalInstance.loginPopup(request).catch(error => {
+            // handle error
+        });
+    } else {
+        // handle error
+    }
+}
+```
+
+However, there's a likelihood of silent sign-in errors if the application has multiple users in a single browser session or if the user has multiple accounts for that single browser session. The following error may be displayed if multiple accounts are available:
+
+```txt
+InteractionRequiredAuthError: interaction_required: AADSTS16000: Either multiple user identities are available for the current request or selected account is not supported for the scenario.
+```
+
+The error indicates that the server couldn't determine which account to sign into, and will require either one of the parameters in the previous example (`account`, `login_hint`, `sid`) or an interactive sign-in to choose the account.
+
+## Considerations when using `ssoSilent`
+
+### Redirect URI (reply URL)
+
+For better performance and to help avoid issues, set the `redirectUri` to a blank page or other page that doesn't use MSAL.
+
+- If the application users only popup and silent methods, set the `redirectUri` on the `PublicClientApplication` configuration object.
+- If the application also uses redirect methods, set the `redirectUri` on a per-request basis.
+
+### Third-party cookies
+
+`ssoSilent` attempts to open a hidden iframe and reuse an existing session with Microsoft Entra ID. This won't work in browsers that block third-party cookies such as Safari, and will lead to an interaction error:
+
+```txt
+InteractionRequiredAuthError: login_required: AADSTS50058: A silent sign-in request was sent but no user is signed in. The cookies used to represent the user's session were not sent in the request to Azure AD
+```
+
+To resolve the error, the user must create an interactive authentication request using the `loginPopup()` or `loginRedirect()`. In some cases, the prompt value **none** can be used together with an interactive MSAL.js method to achieve SSO. See [Interactive requests with prompt=none](msal-js-prompt-behavior.md#interactive-requests-with-promptnone) for more. If you already have the user's sign-in information, you can pass either the `loginHint` or `sid` optional parameters to sign-in a specific account.
+
+## Negating SSO with prompt=login
+
+If you prefer Microsoft Entra ID to prompt the user for entering their credentials despite an active session with the authorization server, you can use the **login** prompt parameter in requests with MSAL.js. See [MSAL.js prompt behavior](msal-js-prompt-behavior.md) for more.
+
+## Sharing authentication state between ADAL.js and MSAL.js
+
+MSAL.js brings feature parity with ADAL.js for Microsoft Entra authentication scenarios. To make the migration from ADAL.js to MSAL.js easy and share authentication state between apps, the library reads the ID token representing user’s session in ADAL.js cache. To take advantage of this when migrating from ADAL.js, you'll need to ensure that the libraries are using `localStorage` for caching tokens. Set the `cacheLocation` to `localStorage` in both the MSAL.js and ADAL.js configuration at initialization as follows:
+
+```javascript
+
+// In ADAL.js
+window.config = {
+  clientId: "1111-2222-3333-4444-55555555",
+  cacheLocation: "localStorage",
+};
+
+var authContext = new AuthenticationContext(config);
+
+// In latest MSAL.js version
+const config = {
+  auth: {
+    clientId: "1111-2222-3333-4444-55555555",
+  },
+  cache: {
+    cacheLocation: "localStorage",
+  },
+};
+
+const msalInstance = new msal.PublicClientApplication(config);
+```
+
+## Next steps
+
+For more information about SSO, see:
+
+- [MSAL.js prompt behavior](msal-js-prompt-behavior.md)
+- [Optional token claims](./optional-claims.md)
+- [Configurable token lifetimes](configurable-token-lifetimes.md)

--- a/msal-javascript-conceptual/use-ie-browser.md
+++ b/msal-javascript-conceptual/use-ie-browser.md
@@ -1,0 +1,54 @@
+---
+title: Issues on Internet Explorer (MSAL.js)
+description: Use the Microsoft Authentication Library for JavaScript (MSAL.js) with Internet Explorer browser.
+services: active-directory
+author: OwenRichards1
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 12/01/2021
+ms.author: owenrichards
+ms.reviewer: saeeda
+ms.custom: aaddev, devx-track-js
+#Customer intent: As an application developer, I want to learn about issues with MSAL.js library so I can decide if this platform meets my application development needs and requirements.
+---
+
+# Known issues on Internet Explorer browsers (MSAL.js)
+
+For better compatibility with Internet Explorer, we generate the Microsoft Authentication Library for JavaScript (MSAL.js) for [JavaScript ES5](https://262.ecma-international.org/5.1/), but there are other things to consider as you develop your application.
+
+## Run an app in Internet Explorer
+
+Internet Explorer lacks native support for JavaScript Promises, required by MSAL.js.
+
+To support JavaScript Promises in an Internet Explorer app, reference a Promise polyfill before you reference MSAL.js.
+
+```html
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"
+  class="pre"
+></script>
+```
+
+## Debugging an application running in Internet Explorer
+
+### Running in production
+
+Deploying your application to production (for instance in Azure Web apps) normally works fine, provided the end user has accepted popups. We tested it with Internet Explorer 11.
+
+### Running locally
+
+To debug your application locally, temporarily disable Internet Explorer's _Protected Mode_ during your debugging session.
+
+  1. In Internet Explorer, select **Tools** > **Internet Options** > **Security** tab > **Internet** zone.
+  1. Clear the **Enable Protected Mode (requires restarting Internet Explorer)** checkbox.
+  1. Select **OK** to restart Internet Explorer.
+
+When you're done debugging, follow the previous steps and select (instead of clear) the **Enable Protected Mode (requires restarting Internet Explorer)** checkbox.
+
+## Next steps
+
+Learn more about [Known issues when using MSAL.js in Internet Explorer](msal-js-known-issues-ie-edge-browsers.md).


### PR DESCRIPTION
The identity platform documentation has reference material for MSAL.js. This repo has been set up to contain MSAL.js documentation.

This PR aims to move and update the identity docs material and include some of the replicated material found in the existing [JavaScript docs](https://github.com/AzureAD/microsoft-authentication-library-for-js)