### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/msal-javascript-conceptual/angular/configuration.md
+++ b/msal-javascript-conceptual/angular/configuration.md
@@ -119,7 +119,7 @@ import { IPublicClientApplication, PublicClientApplication, InteractionType, Bro
 export function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+      clientId: "00001111-aaaa-2222-bbbb-3333cccc4444",
       redirectUri: "http://localhost:4200",
       postLogoutRedirectUri: "http://localhost:4200"
     },

--- a/msal-javascript-conceptual/angular/redirects.md
+++ b/msal-javascript-conceptual/angular/redirects.md
@@ -83,7 +83,7 @@ export function loggerCallback(logLevel: LogLevel, message: string) {
 export function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: '6226576d-37e9-49eb-b201-ec1eeb0029b6',
+      clientId: '00001111-aaaa-2222-bbbb-3333cccc4444',
       redirectUri: 'http://localhost:4200',
       postLogoutRedirectUri: 'http://localhost:4200'
     },


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/microsoft-authentication-library-javascript/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
