### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/msal-javascript-conceptual/browser/caching.md
+++ b/msal-javascript-conceptual/browser/caching.md
@@ -25,7 +25,7 @@ import { PublicClientApplication, BrowserCacheLocation } from "@azure/msal-brows
 
 const pca = new PublicClientApplication({
     auth: {
-        clientId: "Enter_the_Application_Id_Here", // e.g. "b1b60dca-c49d-496e-9851-xxxxxxxxxxxx" (guid)
+        clientId: "Enter_the_Application_Id_Here", // e.g. "00001111-aaaa-2222-bbbb-3333cccc4444" (guid)
         authority: "https://login.microsoftonline.com/Enter_the_Tenant_Info_Here", // e.g. "common" or your tenantId (guid),
         redirectUri: "/"
     },

--- a/msal-javascript-conceptual/browser/performance.md
+++ b/msal-javascript-conceptual/browser/performance.md
@@ -65,7 +65,7 @@ Example event:
 
 ```typescript
 const event: PerformanceEvent = {
-    correlationId: "03cad3ff-6682-4e3d-a0b4-d517b531c718",
+    correlationId: "aaaa0000-bb11-2222-33cc-444444dddddd",
 	durationMs: 1873,
 	endPageVisibility: "hidden",
 	fromCache: false,
@@ -78,7 +78,7 @@ const event: PerformanceEvent = {
     silentIframeClientAcquireTokenDurationMs: 0
     cryptoOptsGetPublicKeyThumbprintDurationMs: 200,
     cryptoOptsSignJwtDurationMs: 8,
-    clientId: "b50703d7-d12b-4ddc-8758-91053fe0aba4",
+    clientId: "00001111-aaaa-2222-bbbb-3333cccc4444",
     authority: "https://login.microsoftonline.com/common",
     libraryName: "@azure/msal-browser-1p",
     libraryVersion: "2.22.2-beta.2",


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/microsoft-authentication-library-javascript/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
