### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/msal-javascript-conceptual/node/caching.md
+++ b/msal-javascript-conceptual/node/caching.md
@@ -30,7 +30,7 @@ require('dotenv').config(); // process.env now has the values defined in a .env 
 // Create msal application object
 const cca = new msal.ConfidentialClientApplication({
     auth: {
-        clientId: "Enter_the_Application_Id_Here", // e.g. "b1b60dca-c49d-496e-9851-xxxxxxxxxxxx" (guid)
+        clientId: "Enter_the_Application_Id_Here", // e.g. "00001111-aaaa-2222-bbbb-3333cccc4444" (guid)
         authority: "https://login.microsoftonline.com/Enter_the_Tenant_Info_Here", // e.g. "common" or your tenantId (guid)
         clientSecret: process.env.clientSecret // obtained during app registration
     }


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/microsoft-authentication-library-javascript/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
