### PR TITLE
Push to prod

### DIFF
--- a/msal-javascript-conceptual/TOC.yml
+++ b/msal-javascript-conceptual/TOC.yml
@@ -156,8 +156,14 @@
       items:
         - name: Supported authorization code grants
           href: node/acquire-token-requests.md
-        - name: Acquire device bound tokens with broker
-          href: node/brokering.md
+        - name: Use brokers
+          items:
+            - name: Windows broker
+              href: node/brokering.md
+            - name: macOS broker
+              href: node/brokering-macos.md
+            - name: Linux broker
+              href: node/brokering-linux.md
         - name: Use managed identity with MSAL Node
           href: node/managed-identity.md
         - name: Use MCP flows with MSAL Node

--- a/msal-javascript-conceptual/node/brokering-linux.md
+++ b/msal-javascript-conceptual/node/brokering-linux.md
@@ -1,0 +1,188 @@
+---
+title: "Using MSAL Node with the Linux Broker"
+description: Learn how to use the Linux broker with MSAL Node to enable single sign-on, install dependencies, and configure secure brokered token acquisition.
+author: Ugonnaak1
+manager: iulico
+ms.author: akaliugonna
+ms.service: msal
+ms.subservice: msal-node
+ms.date: 06/05/2026
+ms.topic: concept-article
+ms.reviewer: dmwendia
+#customer intent: As a developer building a Node.js app on Linux, I want to use the native broker to acquire tokens so that I can provide single sign-on and device-bound token protection.
+---
+# Using MSAL Node with the Linux Broker
+
+Microsoft Authentication Library (MSAL) Node can use the Microsoft Single Sign-on for Linux broker to provide single sign-on (SSO) and secure token acquisition on supported Linux distributions. The broker manages authentication handshakes and token lifecycle, enabling users to benefit from integration with accounts known to the system.
+
+This article explains what the Linux broker is, distributions it supports, and how to enable brokered token acquisition in a Node.js app.
+
+For an overview of broker support across all platforms, see [Using MSAL Node with the Native Token Broker](brokering.md).
+
+## What is the Linux broker
+
+The Microsoft Single Sign-on for Linux is an authentication broker shipped independently of the Linux distribution. Install it with a package manager (`sudo apt install microsoft-identity-broker` or `sudo dnf install microsoft-identity-broker`). It's also bundled as a dependency of Microsoft applications such as [Company Portal](/mem/intune-service/user-help/enroll-device-linux).
+
+Key benefits include:
+
+- **Single sign-on.** Simplifies how users authenticate with Microsoft Entra ID and protects refresh tokens from exfiltration and misuse.
+- **Enhanced security.** Security improvements are delivered via broker updates without requiring app code changes.
+- **Token protection.** The broker ensures refresh tokens are device-bound.
+- **System integration.** Applications plug into the built-in account picker, allowing users to quickly select an existing account.
+
+## Supported distributions
+
+- Ubuntu 22.04 / 24.04 (x64)
+- Red Hat Enterprise Linux (RHEL) 8 / 9 / 10 (x64)
+
+## Prerequisites
+
+- Node.js 18 or later
+- Install `@azure/msal-node-extensions` as a dependency
+- `microsoft-identity-broker` must be installed on the device
+- Register the broker redirect URI on your app registration (see [Redirect URI](#redirect-uri) below)
+- Install the required system dependencies (see [System dependencies](#system-dependencies) below)
+
+## Redirect URI
+
+For Linux broker flows, register the following redirect URI under the **Mobile and desktop applications** platform in the Azure portal:
+
+```text
+https://login.microsoftonline.com/common/oauth2/nativeclient
+```
+
+## System dependencies
+
+# [Ubuntu](#tab/ubuntu)
+
+### Ubuntu 22.04/24.04
+
+```bash
+sudo apt install libsecret-1-0 libdbus-1-3
+```
+
+- **libsecret** — Securely stores and retrieves authentication tokens via the system keyring (GNOME Keyring or KDE Wallet).
+- **dbus** — Inter-process communication with the authentication broker. A D-Bus session bus must be running (standard in desktop environments; headless servers may need `dbus-run-session` or equivalent).
+
+```bash
+sudo apt install libwebkit2gtk-4.1-0 libgtk-3-0
+```
+
+- **WebKitGTK** — Provides the embedded browser for the interactive sign-in UI.
+- **GTK** — The underlying UI toolkit required by WebKitGTK.
+
+# [RHEL](#tab/rhel)
+
+### RHEL 8
+
+```bash
+sudo dnf install libsecret dbus-libs openssl3-libs
+```
+
+- **libsecret** — Securely stores and retrieves authentication tokens via the system keyring (GNOME Keyring or KDE Wallet).
+- **dbus-libs** — Inter-process communication with the authentication broker. A D-Bus session bus must be running (standard in desktop environments; headless servers may need `dbus-run-session` or equivalent).
+- **openssl3-libs** — The native binary is linked against OpenSSL 3 (`libcrypto.so.3`). RHEL 8 ships with OpenSSL 1.1.1 by default, so this package must be explicitly installed. Many RHEL 8 systems already have it as a dependency of other software.
+
+```bash
+sudo dnf install webkit2gtk3 gtk3
+```
+
+### RHEL 9
+
+```bash
+sudo dnf install libsecret dbus-libs
+```
+
+No extra OpenSSL packages needed — OpenSSL 3 is the system default.
+
+```bash
+sudo dnf install webkit2gtk3 gtk3
+```
+
+### RHEL 10
+
+```bash
+sudo dnf install libsecret dbus-libs
+```
+
+No extra OpenSSL packages needed — OpenSSL 3 is the system default.
+
+```bash
+sudo dnf install webkitgtk6.0 gtk4
+```
+
+---
+
+## Enable the feature
+
+Enabling the Linux broker uses the same configuration as Windows and macOS. Pass a `NativeBrokerPlugin` instance in the broker configuration:
+
+```javascript
+import { PublicClientApplication, Configuration } from "@azure/msal-node";
+import { NativeBrokerPlugin } from "@azure/msal-node-extensions";
+
+const msalConfig: Configuration = {
+    auth: {
+        clientId: "your-client-id",
+    },
+    broker: {
+        nativeBrokerPlugin: new NativeBrokerPlugin(),
+    },
+};
+
+const pca = new PublicClientApplication(msalConfig);
+```
+
+> [!NOTE]
+> `msal-node` doesn't fall back to a browser-based flow if the broker is unavailable. Only enable brokered authentication on supported Linux devices to avoid unexpected failures.
+
+## Acquiring tokens
+
+### Interactive token acquisition
+
+Use `acquireTokenInteractive` to request a token through the Linux broker:
+
+```javascript
+const tokenRequest = {
+    scopes: ["User.Read"],
+};
+
+const result = await pca.acquireTokenInteractive(tokenRequest);
+console.log("Access token:", result.accessToken);
+```
+
+### Silent token acquisition
+
+After an initial interactive sign-in, subsequent token requests can be made silently:
+
+```javascript
+const accounts = await pca.getAllAccounts();
+
+if (accounts.length > 0) {
+    const silentRequest = {
+        scopes: ["User.Read"],
+        account: accounts[0],
+    };
+
+    const result = await pca.acquireTokenSilent(silentRequest);
+    console.log("Access token (silent):", result.accessToken);
+}
+```
+
+## Token caching
+
+The authentication broker handles refresh and access token caching. Tokens acquired through the broker are managed by the broker itself and are device-bound. You do not need to set up custom caching when using the broker.
+
+## Differences when using the Linux broker
+
+- When the broker needs to prompt for interaction, a native sign-in dialog (WebKitGTK-based) appears. This changes the user experience (UX) compared to browser-based authentication.
+- The `forceRefresh` parameter for `acquireTokenSilent` is not supported. You may receive a cached token from the broker regardless of this flag.
+- A D-Bus session bus must be running for broker communication to work.
+
+## Limitations
+
+- Azure AD B2C and Active Directory Federation Services (AD FS) authorities are not supported via the Linux broker.
+- Third-party identity providers (IDPs) are not supported.
+- `microsoft-identity-broker` must be installed on the device for the broker to function.
+- `msal-node` does not fall back to a browser if the broker is unavailable. Only enable the broker in environments that support it.
+- Access token proof-of-possession (PoP) is not currently supported through the Linux broker.

--- a/msal-javascript-conceptual/node/brokering-macos.md
+++ b/msal-javascript-conceptual/node/brokering-macos.md
@@ -1,0 +1,141 @@
+---
+title: "Using MSAL Node with the macOS Broker"
+description: Learn how to use MSAL Node with the macOS broker to get device-bound tokens, enable SSO, and configure brokered authentication for macOS apps.
+author: Ugonnaak1
+manager: iulico
+ms.author: akaliugonna
+ms.service: msal
+ms.subservice: msal-node
+ms.date: 06/05/2026
+ms.topic: concept-article
+ms.reviewer: dmwendia
+#customer intent: As a developer building a Node.js app on macOS, I want to use the native broker to acquire tokens so that I can provide single sign-on and device-bound token protection.
+---
+# Using MSAL Node with the macOS Broker
+
+Microsoft Authentication Library (MSAL) Node can use the macOS authentication broker to provide single sign-on (SSO) and secure token acquisition by using accounts known to the operating system. This article explains the macOS broker and how to enable and use brokered authentication in MSAL Node.
+
+For an overview of broker support across all platforms, see [Using MSAL Node with the Native Token Broker](brokering.md).
+
+## What is the macOS broker
+
+On macOS, the authentication broker is provided by the [Microsoft Enterprise SSO plug-in for Apple devices](/entra/identity-platform/apple-sso-plugin), which ships with the **Company Portal** app. The broker manages authentication handshakes and token lifecycle for connected accounts. Key benefits include:
+
+- **Enhanced security.** Security improvements are delivered via broker updates without requiring app code changes. Refresh tokens are device-bound and protected from exfiltration.
+- **System integration.** Users can reuse existing signed-in accounts from Company Portal, reducing credential re-entry.
+- **Token protection.** The broker ensures refresh tokens are bound to the device context.
+
+## Supported platforms and architectures
+
+| Component               | Supported                             |
+| ----------------------- | ------------------------------------- |
+| **Architecture**  | ARM64 (Apple Silicon) and x64 (Intel) |
+| **macOS version** | macOS 10.15 (Catalina) and later      |
+
+> [!TIP]
+> We recommend updating to the latest macOS version to ensure compatibility with the newest security features and broker capabilities.
+
+## Prerequisites
+
+- Node.js 18 or later
+- Install `@azure/msal-node-extensions` as a dependency
+- The device must be enrolled via [Company Portal](/intune/intune-service/user-help/enroll-your-device-in-intune-macos-cp). After enrollment, verify that other Microsoft apps can sign in via the SSO extension (for example, you can sign in to Word via Company Portal).
+- Register the broker redirect URI on your app registration. For the supported URI values, see [Redirect URI](#redirect-uri).
+
+## Redirect URI
+
+For macOS broker flows, you must register a platform-specific redirect URI under the **Mobile and desktop applications** platform in the Azure portal.
+
+**For unsigned applications (scripts, CLI tools):**
+
+Use the following redirect URI for unsigned applications, such as scripts and CLI tools:
+
+```text
+msauth.com.msauth.unsignedapp://auth
+```
+
+**For signed/bundled applications:**
+
+Use the following redirect URI format for signed or bundled applications:
+
+```text
+msauth.<your-bundle-id>://auth
+```
+
+Replace `<your-bundle-id>` with your application's Apple bundle identifier (e.g., `msauth.com.example.myapp://auth`).
+
+> [!IMPORTANT]
+> The broker redirect URI should **only** be used for broker flows. If your application also uses browser-based authentication flows, use a separate redirect URI for those. Providing the broker redirect URI to a browser-based flow will result in an error.
+
+## Enable the feature
+
+Enabling the macOS broker requires the same configuration as Windows. Pass a `NativeBrokerPlugin` instance in the broker configuration:
+
+```javascript
+import { PublicClientApplication, Configuration } from "@azure/msal-node";
+import { NativeBrokerPlugin } from "@azure/msal-node-extensions";
+
+const msalConfig: Configuration = {
+    auth: {
+        clientId: "your-client-id",
+    },
+    broker: {
+        nativeBrokerPlugin: new NativeBrokerPlugin(),
+    },
+};
+
+const pca = new PublicClientApplication(msalConfig);
+```
+
+> [!NOTE]
+> `msal-node` doesn't fall back to a browser-based flow if the broker is unavailable. Only enable brokered authentication in environments that support the broker to avoid unexpected failures.
+
+## Acquiring tokens
+
+### Interactive token acquisition
+
+Use `acquireTokenInteractive` to request a token through the macOS broker:
+
+```javascript
+const tokenRequest = {
+    scopes: ["User.Read"],
+};
+
+const result = await pca.acquireTokenInteractive(tokenRequest);
+console.log("Access token:", result.accessToken);
+```
+
+### Silent token acquisition
+
+After an initial interactive sign-in, subsequent token requests can be made silently:
+
+```javascript
+const accounts = await pca.getAllAccounts();
+
+if (accounts.length > 0) {
+    const silentRequest = {
+        scopes: ["User.Read"],
+        account: accounts[0],
+    };
+
+    const result = await pca.acquireTokenSilent(silentRequest);
+    console.log("Access token (silent):", result.accessToken);
+}
+```
+
+## Token caching
+
+The authentication broker handles refresh and access token caching. Tokens acquired through the broker are managed by the broker itself and are device-bound. You don't need to set up custom caching when using the broker.
+
+## Differences when using the macOS broker
+
+- When the broker needs to prompt for interaction, a native macOS authentication dialog appears. This changes the user experience (UX) compared to browser-based authentication.
+- The `forceRefresh` parameter for `acquireTokenSilent` is not supported. You may receive a cached token from the broker regardless of this flag.
+- Access token proof-of-possession (PoP) is supported through the broker.
+
+## Limitations
+
+- Azure AD B2C and Active Directory Federation Services (AD FS) authorities are not supported via the macOS broker.
+- Third-party identity providers (IDPs) are not supported.
+- Company Portal must be installed and the device must be enrolled for the broker to function.
+- `msal-node` does not fall back to a browser if the broker is unavailable. Only enable the broker in environments that support it.

--- a/msal-javascript-conceptual/node/brokering.md
+++ b/msal-javascript-conceptual/node/brokering.md
@@ -1,29 +1,63 @@
 ---
-title: "Acquiring Device Bound Tokens"
-description: Learn how to acquire device bound tokens from the native token broker.
+title: "Using MSAL Node with the Native Token Broker (Windows)"
+description: Learn how to use the native token broker on Windows with MSAL Node to acquire device-bound tokens, configure proof-of-possession, and understand broker-specific behavior.
 author: Dickson-Mwendia
 manager: Dougeby
 ms.author: dmwendia
 ms.service: msal
 ms.subservice: msal-node
-ms.date: 03/15/2026
+ms.date: 06/05/2026
 ms.topic: concept-article
 ms.reviewer: kengaderdus
-#Customer intent: As a developer, I want to learn how to acquire tokens from the native token broker.
+#customer intent: As a developer building a Node.js app on Windows, I want to use the native token broker to acquire tokens so that I can provide single sign-on and device-bound token protection.
 ---
 
-# Acquiring Device Bound Tokens
+# Using MSAL Node with the Native Token Broker (Windows)
 
-MSAL Node supports acquiring tokens from the native token broker. When using the native broker refresh tokens are bound to the device on which they are acquired on and are not accessible by `msal-node` or the application. This provides a higher level of security that cannot be achieved by `msal-node` alone. This feature is currently only supported on Windows.
+Microsoft Authentication Library (MSAL) Node supports acquiring tokens from the native token broker. When using the native broker, refresh tokens are bound to the device on which they are acquired and are not accessible by `msal-node` or the application. This provides a higher level of security that cannot be achieved by `msal-node` alone. 
+
+This article explains how to configure the Windows broker, set up proof-of-possession, and understand broker-specific behavior.
+
+Broker support is available on the following platforms:
+
+| Platform | Broker | Documentation |
+|----------|--------|---------------|
+| **Windows** | Web Account Manager (WAM) | Windows broker (this article) |
+| **macOS** | Microsoft Enterprise SSO plug-in (Company Portal) | [macOS broker](brokering-macos.md) |
+| **Linux** | Microsoft Single Sign-on for Linux | [Linux broker](brokering-linux.md) |
+
+## What is a broker
+
+An authentication broker is a component that runs on a user's machine and manages authentication handshakes and token lifecycle for connected accounts. On Windows, this role is performed by Web Account Manager (WAM). Key benefits include:
+
+- **Enhanced security.** Security improvements are delivered via OS or broker updates without requiring app code changes. Refresh tokens are device-bound and protected from exfiltration.
+- **Feature support.** Access to rich OS capabilities such as Windows Hello, Microsoft Entra Conditional Access policies, and Fast Identity Online (FIDO) security keys without extra scaffolding code.
+- **System integration.** Applications plug into the built-in account picker, allowing users to quickly select an existing account instead of re-entering credentials.
+- **Token protection.** The broker ensures refresh tokens are device-bound and [enables apps to acquire proof-of-possession access tokens](#proof-of-possession).
+
+## Supported architectures
+
+- Windows: x64, x86, ARM64
 
 ## Prerequisites
 
+- Node.js 18 or later
 - Install `@azure/msal-node-extensions` as a dependency
-- Register the broker's redirectUri on your app registration: `ms-appx-web://Microsoft.AAD.BrokerPlugin/<your-client-id>`, replacing `<your-client-id>` with your clientId.
+- Register the broker's redirect URI on your app registration. For the required value, see [Redirect URI](#redirect-uri).
+
+## Redirect URI
+
+Register the following redirect URI under the **Mobile and desktop applications** platform in the Azure portal:
+
+```text
+ms-appx-web://Microsoft.AAD.BrokerPlugin/<your-client-id>
+```
+
+Replace `<your-client-id>` with your application's client ID.
 
 ## Enable the feature
 
-Enabling token brokering requires just 1 new configuration parameter:
+Enabling token brokering requires just one configuration parameter. Pass a `NativeBrokerPlugin` instance in the broker configuration:
 
 ```javascript
 import { PublicClientApplication, Configuration } from "@azure/msal-node";
@@ -31,45 +65,47 @@ import { NativeBrokerPlugin } from "@azure/msal-node-extensions";
 
 const msalConfig: Configuration = {
     auth: {
-        clientId: "your-client-id"
+        clientId: "your-client-id",
     },
     broker: {
-        nativeBrokerPlugin: new NativeBrokerPlugin()
-    }
+        nativeBrokerPlugin: new NativeBrokerPlugin(),
+    },
 };
 
 const pca = new PublicClientApplication(msalConfig);
 ```
 
-Please note that `msal-node` will _not_ fallback to the non-brokered flow in the event of a failure. In order to avoid unexpected failures in the future, only enable the broker flow in environments which support it.
+> [!NOTE]
+> `msal-node` will _not_ fall back to the non-brokered flow in the event of a failure. Only enable the broker flow in environments that support it to avoid unexpected failures.
 
-A working sample can be found in the [auth-code-cli-brokered-app sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/auth-code-cli-brokered-app)
+A working sample can be found in the [auth-code-cli-brokered-app sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/auth-code-cli-brokered-app).
 
-## Window Parenting
+## Window parenting
 
-In order for auth prompts to display over the top of the calling application and block further interaction, you will need to provide the application's "window handle" to the `acquireTokenInteractive' API.
+In order for auth prompts to display over the calling application and block further interaction, provide the application's window handle to the `acquireTokenInteractive` API.
 
-For CLI apps a best effort attempt to find the window handle is made under the hood, but it is unreliable.
+For CLI apps, a best-effort attempt to find the window handle is made under the hood, but it is unreliable.
 
-If you're using Electron you can use the [`getNativeWindowHandle` Electron exposes](https://www.electronjs.org/docs/latest/api/browser-window#wingetnativewindowhandle) and pass the result into `acquireTokenInteractive`
+If you're using Electron, use the [`getNativeWindowHandle`](https://www.electronjs.org/docs/latest/api/browser-window#wingetnativewindowhandle) API and pass the result into `acquireTokenInteractive`:
 
-```js
-import { BrowserWindow } from 'electron';
+```javascript
+import { BrowserWindow } from "electron";
 
 const win = new BrowserWindow();
-
 const pca = new PublicClientApplication(msalConfig);
 
 pca.acquireTokenInteractive({
-    windowHandle: win.getNativeWindowHandle()
+    windowHandle: win.getNativeWindowHandle(),
 });
 ```
 
-## Proof of Possession
+<a name='proof-of-possession'></a>
 
-Access token proof of possession (PoP) is supported when acquiring tokens through the native broker. To request a PoP token, add the following properties to the request object provided to `acquireTokenInteractive` or `acquireTokenSilent`.
+## Proof of possession
 
-### AT PoP Request Parameters
+Access token proof of possession (PoP) is supported when acquiring tokens through the native broker. To request a PoP token, add the following properties to the request object provided to `acquireTokenInteractive` or `acquireTokenSilent`:
+
+### AT PoP request parameters
 
 | Name | Description | Required |
 |---|---|---|
@@ -78,7 +114,9 @@ Access token proof of possession (PoP) is supported when acquiring tokens throug
 | `resourceRequestUri` | The URL of the protected resource for which the access token is being issued | **Required** |
 | `shrNonce` | A server-generated, signed timestamp that is Base64URL encoded as a string. This nonce is used to mitigate clock-skew and time-travel attacks meant to enable PoP token pre-generation. | *Optional* |
 
-### Usage Example
+### Usage example
+
+This example requests a proof-of-possession token by setting the authentication scheme and signed HTTP request properties:
 
 ```javascript
 import { PublicClientApplication, Configuration, AuthenticationScheme } from "@azure/msal-node";
@@ -110,10 +148,12 @@ pca.acquireTokenSilent(popTokenRequest);
 > [!NOTE]
 > Access token proof-of-possession is only supported through the native broker flow and is not available in the non-brokered flow.
 
-## Differences when using the broker to acquire tokens
+<a name='differences-when-using-the-broker-to-acquire-tokens'></a>
 
-There are a few things that may behave a little differently when acquiring tokens through the native broker.
+## Differences when using the Windows broker
+
+There are a few things that may behave differently when acquiring tokens through the native broker:
 
 - The `forceRefresh` parameter for `acquireTokenSilent` calls is not supported. You may receive a cached token from the broker regardless of what this flag is set to.
-- If the broker needs to prompt the user for interaction, a system prompt will be opened. This is a UX change as authentication will not occur in a browser window.
-- Access token proof-of-possession _is_ supported by the broker but _is not_ supported by the non-brokered flow
+- If the broker needs to prompt the user for interaction, a system prompt opens. This changes the user experience (UX) because authentication doesn't occur in a browser window.
+- Access token proof-of-possession _is_ supported by the broker but _is not_ supported by the non-brokered flow.


### PR DESCRIPTION
* docs: Add Node.js broker documentation for macOS and Linux

- Update brokering.md (Windows) with platform support table and correct architectures
- Add brokering-macos.md for macOS broker support via Company Portal
- Add brokering-linux.md for Linux broker support with system dependency guides
